### PR TITLE
Feat/throttling & debug mode `(v1.42)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ sudo python3 wifi_deauth.py -i <iface>
 * `--autostart` - start the de-auth loop automatically, works only when one access point is found
 * `--channels <ch1,ch2>` - scan for specific channels only, otherwise all supported channels will be scanned
 * `--clients <m_addr1,m_addr2>` - target only specific clients to disconnect from the AP, otherwise all connected clients will be targeted (note: using this option disables deauth broadcast)
+* `--debug` - enable debug prints
 * `--kill` (or run `sudo systemctl stop NetworkManager`) - kill NetworkManager service which might interfere with the attack
 * `--skip-monitormode` - enable monitor mode manually (otherwise the program does it automatically)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='wifi_deauth',
-    version='1.41',
+    version='1.42',
     description='WiFi deauthentication tool built with Python using the Scapy library',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/wifi_deauth/utils/output_manager.py
+++ b/wifi_deauth/utils/output_manager.py
@@ -52,7 +52,7 @@ def print_cmd(text):
 
 
 def print_debug(text):
-    printf(f"[{BOLD}{RED}~{RESET}] {text}")
+    printf(f"[{BOLD}{YELLOW}~{RESET}] {text}")
 
 
 BANNER = f"""

--- a/wifi_deauth/utils/output_manager.py
+++ b/wifi_deauth/utils/output_manager.py
@@ -51,6 +51,10 @@ def print_cmd(text):
     printf(f"[{BOLD}{GREEN}>{RESET}] {text}")
 
 
+def print_debug(text):
+    printf(f"[{BOLD}{RED}~{RESET}] {text}")
+
+
 BANNER = f"""
 {BOLD}{RED} __      __ {RESET}__  _____ __         {BOLD}{RED}_________{RESET}                         __   __     
 {BOLD}{RED}/  \    /  \\{RESET}__|/ ____\__|        {BOLD}{RED}\    __  \\{RESET}  _____ ______   __ ___/  |_|  |__  

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -70,7 +70,7 @@ class Interceptor:
                 print_error(f"Failed to kill NetworkManager...")
 
         self._channel_range = {channel: defaultdict(dict) for channel in self._get_channels()}
-        self.log_debug(f"Supported channels: {self._channel_range.keys()}")
+        self.log_debug(f"Supported channels: {[c for c in self._channel_range.keys()]}")
         self._all_ssids: Dict[BandType, Dict[str, SSID]] = {band: dict() for band in BandType}
         self._custom_ssid_name: Union[str, None] = self.parse_custom_ssid_name(ssid_name)
         self.log_debug(f"Selected custom ssid name: {self._custom_ssid_name}")

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -395,6 +395,8 @@ class Interceptor:
             print_info(f"Target clients{BOLD}{str(len(self._get_target_clients())).rjust(80 - 18, ' ')}{RESET}")
             print_info(f"Elapsed sec {BOLD}{str(get_time() - start).rjust(80 - 16, ' ')}{RESET}")
             sleep(Interceptor._PRINT_STATS_INTV)
+            if Interceptor._ABORT:  # might change while sleeping
+                break
             clear_line(7 + buffer_sz)
 
     def log_debug(self, msg: str):

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -37,7 +37,7 @@ conf.verb = 0
 class Interceptor:
     _ABORT = False
     _PRINT_STATS_INTV = 1
-    _DEAUTH_INTV = 0.1
+    _DEAUTH_INTV = 0.05  # 50[ms]
     _CH_SNIFF_TO = 2
     _SSID_STR_PAD = 42  # total len 80
 

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -394,7 +394,7 @@ class Interceptor:
             print_info(f"Net interface{self.interface.rjust(80 - 17, ' ')}")
             print_info(f"Target clients{BOLD}{str(len(self._get_target_clients())).rjust(80 - 18, ' ')}{RESET}")
             print_info(f"Elapsed sec {BOLD}{str(get_time() - start).rjust(80 - 16, ' ')}{RESET}")
-            sleep(Interceptor._PRINT_STATS_INVT)
+            sleep(Interceptor._PRINT_STATS_INTV)
             clear_line(7 + buffer_sz)
 
     def log_debug(self, msg: str):
@@ -410,7 +410,7 @@ class Interceptor:
         with Interceptor._ABORT_LCK:
             if not Interceptor._ABORT:
                 Interceptor._ABORT = True
-                sleep(Interceptor._PRINT_STATS_INVT * 1.1)  # let prints finish
+                sleep(Interceptor._PRINT_STATS_INTV * 1.1)  # let prints finish
                 printf(f"{DELIM}")
                 print_error(msg)
                 exit(0)

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -36,7 +36,6 @@ conf.verb = 0
 
 class Interceptor:
     _ABORT = False
-    _ABORT_LCK = threading.Lock()
     _PRINT_STATS_INTV = 1
     _DEAUTH_INTV = 0.1
     _CH_SNIFF_TO = 2
@@ -409,13 +408,12 @@ class Interceptor:
 
     @staticmethod
     def abort_run(msg: str):
-        with Interceptor._ABORT_LCK:
-            if not Interceptor._ABORT:
-                Interceptor._ABORT = True
-                sleep(Interceptor._PRINT_STATS_INTV * 1.1)  # let prints finish
-                printf(f"{DELIM}")
-                print_error(msg)
-                exit(0)
+        if not Interceptor._ABORT:  # thread-safe due to GIL
+            Interceptor._ABORT = True
+            sleep(Interceptor._PRINT_STATS_INTV * 1.1)  # let prints finish
+            printf(f"{DELIM}")
+            print_error(msg)
+            exit(0)
 
 
 def main():

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -45,7 +45,7 @@ class Interceptor:
                  ssid_name, bssid_addr, custom_client_macs, custom_channels, autostart, debug_mode):
         self.interface = net_iface
 
-        self._max_consecutive_failed_send_cnt = 5 / Interceptor._DEAUTH_INTV  # fails to send for 5 consecutive seconds
+        self._max_consecutive_failed_send_lim = 5 / Interceptor._DEAUTH_INTV  # fails to send for 5 consecutive seconds
 
         self._current_channel_num = None
         self._current_channel_aps = set()
@@ -330,7 +330,7 @@ class Interceptor:
                     failed_attempts_ctr = 0  # reset counter
                 except Exception as exc:
                     failed_attempts_ctr += 1
-                    if failed_attempts_ctr >= self._max_consecutive_failed_send_cnt:
+                    if failed_attempts_ctr >= self._max_consecutive_failed_send_lim:
                         raise exc
                     sleep(Interceptor._DEAUTH_INTV)  # if exception - sleep to throttle down
         except Exception as exc:

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -332,7 +332,7 @@ class Interceptor:
                     failed_attempts_ctr += 1
                     if failed_attempts_ctr >= self._max_consecutive_failed_send_cnt:
                         raise exc
-                    sleep(Interceptor._DEAUTH_INTV)  # sleep to throttle down on exceptions
+                    sleep(Interceptor._DEAUTH_INTV)  # if exception - sleep to throttle down
         except Exception as exc:
             Interceptor.abort_run(f"Exception '{exc}' in deauth-loop -> {traceback.format_exc()}")
 
@@ -369,18 +369,6 @@ class Interceptor:
 
         for t in threads:
             t.join()
-
-        # TODO - I remove daemon
-        # TODO print info stats into thread as well
-        # TODO start all 3 threads and join them
-        # TODO when printing exception somewhere and setting abort as false, put a small sleep (u can wrap it) so that exception prints well
-        # TODO debug prints
-        # TODO test - raise exc and see output
-        # TODO test - start and finish entire run
-        # TODO test - debug
-
-        # TODO update version
-        # TODO docs debug mode
 
     def report_status(self):
         start = get_time()

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -37,16 +37,15 @@ conf.verb = 0
 class Interceptor:
     _ABORT = False
     _ABORT_LCK = threading.Lock()
-    _PRINT_STATS_INVT = 1
+    _PRINT_STATS_INTV = 1
+    _DEAUTH_INTV = 0.1
+    _CH_SNIFF_TO = 2
+    _SSID_STR_PAD = 42  # total len 80
 
     def __init__(self, net_iface, skip_monitor_mode_setup, kill_networkmanager,
-                 ssid_name, bssid_addr, custom_client_macs, custom_channels, autostart):
+                 ssid_name, bssid_addr, custom_client_macs, custom_channels, autostart, debug_mode):
         self.interface = net_iface
-        self._channel_sniff_timeout = 2
-        self._scan_intv = 0.1
-        self._deauth_intv = 0.1
-        self._max_consecutive_failed_send_cnt = 5 / self._deauth_intv  # if fails to send for 5 seconds consecutively
-        self._ssid_str_pad = 42  # total len 80
+        self._max_consecutive_failed_send_cnt = 5 / Interceptor._DEAUTH_INTV  # if fails to send for 5 seconds consecutively
 
         self._current_channel_num = None
         self._current_channel_aps = set()
@@ -54,6 +53,7 @@ class Interceptor:
         self.attack_loop_count = 0
 
         self.target_ssid: Union[SSID, None] = None
+        self._debug_mode = debug_mode
 
         if not skip_monitor_mode_setup:
             print_info(f"Setting up monitor mode...")
@@ -70,14 +70,18 @@ class Interceptor:
                 print_error(f"Failed to kill NetworkManager...")
 
         self._channel_range = {channel: defaultdict(dict) for channel in self._get_channels()}
+        self.log_debug(f"Supported channels: {self._channel_range.keys()}")
         self._all_ssids: Dict[BandType, Dict[str, SSID]] = {band: dict() for band in BandType}
-
         self._custom_ssid_name: Union[str, None] = self.parse_custom_ssid_name(ssid_name)
+        self.log_debug(f"Selected custom ssid name: {self._custom_ssid_name}")
         self._custom_bssid_addr: Union[str, None] = self.parse_custom_bssid_addr(bssid_addr)
+        self.log_debug(f"Selected custom bssid addr: {self._custom_ssid_name}")
         self._custom_target_client_mac: Union[List[str], None] = self.parse_custom_client_mac(custom_client_macs)
+        self.log_debug(f"Selected arget client mac addrs: {self._custom_target_client_mac}")
         self._custom_target_ap_channels: List[int] = self.parse_custom_channels(custom_channels)
-        self._custom_target_ap_last_ch = 0  # to avoid overlapping
+        self.log_debug(f"Selected target client channels: {self._custom_target_client_mac}")
 
+        self._custom_target_ap_last_ch = 0  # to avoid overlapping
         self._midrun_output_buffer: List[str] = list()
         self._midrun_output_lck = threading.RLock()
 
@@ -196,7 +200,6 @@ class Interceptor:
         print_info(f"Starting AP scan, please wait... ({len(channels_to_scan)} channels total)")
         if self._custom_ssid_name_is_set():
             print_info(f"Scanning for target SSID -> {self._custom_ssid_name}")
-
         try:
             for idx, ch_num in enumerate(channels_to_scan):
                 if self._custom_ssid_name_is_set() and self._found_custom_ssid_name() \
@@ -206,7 +209,7 @@ class Interceptor:
                 self._set_channel(ch_num)
                 print_info(f"Scanning channel {self._current_channel_num} (left -> "
                            f"{len(channels_to_scan) - (idx + 1)})", end="\r")
-                sniff(prn=self._ap_sniff_cb, iface=self.interface, timeout=self._channel_sniff_timeout,
+                sniff(prn=self._ap_sniff_cb, iface=self.interface, timeout=Interceptor._CH_SNIFF_TO,
                       stop_filter=lambda p: Interceptor._ABORT is True)
         finally:
             printf("")
@@ -270,7 +273,7 @@ class Interceptor:
         return target_map[chosen]
 
     def _generate_ssid_str(self, ssid, ch, mcaddr, preflen):
-        return f"{ssid.ljust(self._ssid_str_pad - preflen, ' ')}{str(ch).ljust(3, ' ').ljust(self._ssid_str_pad // 2, ' ')}{mcaddr}"
+        return f"{ssid.ljust(Interceptor._SSID_STR_PAD - preflen, ' ')}{str(ch).ljust(3, ' ').ljust(Interceptor._SSID_STR_PAD // 2, ' ')}{mcaddr}"
 
     def _clients_sniff_cb(self, pkt):
         try:
@@ -329,7 +332,7 @@ class Interceptor:
                     failed_attempts_ctr += 1
                     if failed_attempts_ctr >= self._max_consecutive_failed_send_cnt:  # todo place exception in send to test this
                         raise exc
-            sleep(self._deauth_intv)
+            sleep(Interceptor._DEAUTH_INTV)
         except Exception as exc:
             Interceptor.abort_run(f"Exception in deauth-loop -> {traceback.format_exc()}")
 
@@ -374,7 +377,10 @@ class Interceptor:
         # TODO debug prints
         # TODO test - raise exc and see output
         # TODO test - start and finish entire run
+        # TODO test - debug
+
         # TODO update version
+        # TODO docs debug mode
 
     def report_status(self):
         start = get_time()
@@ -390,6 +396,10 @@ class Interceptor:
             print_info(f"Elapsed sec {BOLD}{str(get_time() - start).rjust(80 - 16, ' ')}{RESET}")
             sleep(Interceptor._PRINT_STATS_INVT)
             clear_line(7 + buffer_sz)
+
+    def log_debug(self, msg: str):
+        if self._debug_mode:
+            print_debug(msg)
 
     @staticmethod
     def user_abort(*_):
@@ -420,7 +430,6 @@ def main():
 
     if "linux" not in sys.platform:
         raise Exception(f"Unsupported operating system {sys.platform}, only linux is supported...")
-    
 
     parser = argparse.ArgumentParser(description='A simple program to perform a deauth attack')
     parser.add_argument('-i', '--iface', help='a network interface with monitor mode enabled (i.e -> "eth0")',
@@ -440,6 +449,8 @@ def main():
                         metavar="ch1,ch2", action='store', default=None, dest="custom_channels", required=False)
     parser.add_argument('-a', '--autostart', help='autostart the de-auth loop (if the scan result contains a single access point)',
                         action='store_true', default=False, dest="autostart", required=False)
+    parser.add_argument('-d', '--debug', help='enable debug prints',
+                        action='store_true', default=False, dest="debug_mode", required=False)
     pargs = parser.parse_args()
 
     invalidate_print()  # after arg parsing
@@ -450,7 +461,8 @@ def main():
                            bssid_addr=pargs.custom_bssid,
                            custom_client_macs=pargs.custom_client_macs,
                            custom_channels=pargs.custom_channels,
-                           autostart=pargs.autostart)
+                           autostart=pargs.autostart,
+                           debug_mode=pargs.debug_mode)
     attacker.run()
 
 

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -331,7 +331,7 @@ class Interceptor:
                     failed_attempts_ctr += 1
                     if failed_attempts_ctr >= self._max_consecutive_failed_send_cnt:  # todo place exception in send to test this
                         raise exc
-            sleep(Interceptor._DEAUTH_INTV)
+                sleep(Interceptor._DEAUTH_INTV)
         except Exception as exc:
             Interceptor.abort_run(f"Exception in deauth-loop -> {traceback.format_exc()}")
 

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -355,6 +355,11 @@ class Interceptor:
             t = Thread(target=action, args=tuple(), daemon=True)
             t.start()
 
+        # TODO print info stats into thread as well
+        # TODO start all 3 threads and join them
+        # TODO when printing exception somewhere and setting abort as false, put a small sleep (u can wrap it) so that exception prints well
+        # TODO debug prints
+
         start = get_time()
         printf(f"{DELIM}\n")
 

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -47,7 +47,7 @@ class Interceptor:
         self.interface = net_iface
 
         if deauth_intv:
-            Interceptor._DEAUTH_INTV = deauth_intv
+            Interceptor._DEAUTH_INTV = float(deauth_intv)
             print_debug(f"Deauth interval was set to {Interceptor._DEAUTH_INTV}[s]")
         self._max_consecutive_failed_send_cnt = 5 / Interceptor._DEAUTH_INTV  # if fails to send for 5 seconds consecutively
 

--- a/wifi_deauth/wifi_deauth.py
+++ b/wifi_deauth/wifi_deauth.py
@@ -37,13 +37,18 @@ conf.verb = 0
 class Interceptor:
     _ABORT = False
     _PRINT_STATS_INTV = 1
-    _DEAUTH_INTV = 0.05  # 50[ms]
+    _DEAUTH_INTV = 0.01  # 10[ms]
     _CH_SNIFF_TO = 2
     _SSID_STR_PAD = 42  # total len 80
 
     def __init__(self, net_iface, skip_monitor_mode_setup, kill_networkmanager,
-                 ssid_name, bssid_addr, custom_client_macs, custom_channels, autostart, debug_mode):
+                 ssid_name, bssid_addr, custom_client_macs, custom_channels, autostart,
+                 deauth_intv, debug_mode):
         self.interface = net_iface
+
+        if deauth_intv:
+            Interceptor._DEAUTH_INTV = deauth_intv
+            print_debug(f"Deauth interval was set to {Interceptor._DEAUTH_INTV}[s]")
         self._max_consecutive_failed_send_cnt = 5 / Interceptor._DEAUTH_INTV  # if fails to send for 5 seconds consecutively
 
         self._current_channel_num = None
@@ -333,7 +338,7 @@ class Interceptor:
                         raise exc
                 sleep(Interceptor._DEAUTH_INTV)
         except Exception as exc:
-            Interceptor.abort_run(f"Exception in deauth-loop -> {traceback.format_exc()}")
+            Interceptor.abort_run(f"Exception '{exc}' in deauth-loop -> {traceback.format_exc()}")
 
     def _send_deauth_client(self, ap_mac: str, client_mac: str):
         sendp(RadioTap() /
@@ -449,6 +454,8 @@ def main():
                         metavar="ch1,ch2", action='store', default=None, dest="custom_channels", required=False)
     parser.add_argument('-a', '--autostart', help='autostart the de-auth loop (if the scan result contains a single access point)',
                         action='store_true', default=False, dest="autostart", required=False)
+    parser.add_argument('--deauth-interval', help='sleep interval between each deauth cycle in seconds (i.e -> 0.1 for 100 milliseconds)',
+                        action='store', default=None, dest="deauth_intv", required=False)
     parser.add_argument('-d', '--debug', help='enable debug prints',
                         action='store_true', default=False, dest="debug_mode", required=False)
     pargs = parser.parse_args()
@@ -462,6 +469,7 @@ def main():
                            custom_client_macs=pargs.custom_client_macs,
                            custom_channels=pargs.custom_channels,
                            autostart=pargs.autostart,
+                           deauth_intv=pargs.deauth_intv,
                            debug_mode=pargs.debug_mode)
     attacker.run()
 


### PR DESCRIPTION
advancing version `1.41` -> `1.42`

## New Features
* Deauth loop - exit after 5 consecutive seconds of exceptions, and throttle down (100ms sleep) between each failed deauth attempt (https://github.com/flashnuke/wifi-deauth/issues/23)
* Debug mode (`-d`, `--debug) to enable debug prints

## Bugfixes
* fixed a bug where sometimes a backtrace of an exception was not printed fully
